### PR TITLE
Add offset-based region data store

### DIFF
--- a/BlazorDatasheet.DataStructures/Store/OffsetManager.cs
+++ b/BlazorDatasheet.DataStructures/Store/OffsetManager.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+
+namespace BlazorDatasheet.DataStructures.Store;
+
+/// <summary>
+/// Tracks index offsets resulting from insert and delete operations.
+/// The offsets are stored as a difference list so the cumulative
+/// offset at an index can be calculated quickly.
+/// </summary>
+internal class OffsetManager
+{
+    private readonly SortedDictionary<int, int> _diff = new();
+
+    private int GetCumulative(int index)
+    {
+        int offset = 0;
+        foreach (var kv in _diff)
+        {
+            if (kv.Key > index)
+                break;
+            offset += kv.Value;
+        }
+        return offset;
+    }
+
+    public int ToPhysical(int logical)
+    {
+        return logical - GetCumulative(logical);
+    }
+
+    public bool IsInserted(int logical)
+    {
+        var prev = GetCumulative(logical - 1);
+        var curr = GetCumulative(logical);
+        return curr > prev;
+    }
+
+    public void Insert(int index, int count)
+    {
+        if (count == 0)
+            return;
+        if (_diff.ContainsKey(index))
+            _diff[index] += count;
+        else
+            _diff.Add(index, count);
+    }
+
+    public void Remove(int index, int count)
+    {
+        if (count == 0)
+            return;
+        if (_diff.ContainsKey(index))
+            _diff[index] -= count;
+        else
+            _diff.Add(index, -count);
+    }
+}

--- a/BlazorDatasheet.DataStructures/Store/OffsetRegionDataStore.cs
+++ b/BlazorDatasheet.DataStructures/Store/OffsetRegionDataStore.cs
@@ -1,0 +1,89 @@
+using BlazorDatasheet.DataStructures.Geometry;
+using System.Linq;
+
+namespace BlazorDatasheet.DataStructures.Store;
+
+/// <summary>
+/// Region data store that applies row/column offsets instead of
+/// shifting all data when rows or columns are inserted.
+/// </summary>
+public class OffsetRegionDataStore<T> : RegionDataStore<T> where T : IEquatable<T>
+{
+    private readonly OffsetManager _rowOffsets = new();
+    private readonly OffsetManager _colOffsets = new();
+
+    public OffsetRegionDataStore(int minArea = 0, bool expandWhenInsertAfter = true)
+        : base(minArea, expandWhenInsertAfter)
+    {
+    }
+
+    private int PhysicalRow(int logicalRow) => _rowOffsets.ToPhysical(logicalRow);
+    private int PhysicalCol(int logicalCol) => _colOffsets.ToPhysical(logicalCol);
+
+    private bool RowInserted(int row) => _rowOffsets.IsInserted(row);
+    private bool ColInserted(int col) => _colOffsets.IsInserted(col);
+
+    public new bool Contains(int row, int col)
+    {
+        if (RowInserted(row) || ColInserted(col))
+            return false;
+        return base.Contains(PhysicalRow(row), PhysicalCol(col));
+    }
+
+    public new IEnumerable<DataRegion<T>> GetDataRegions(int row, int col)
+    {
+        if (RowInserted(row) || ColInserted(col))
+            return Enumerable.Empty<DataRegion<T>>();
+        return base.GetDataRegions(PhysicalRow(row), PhysicalCol(col));
+    }
+
+    public new IEnumerable<DataRegion<T>> GetDataRegions(IRegion region)
+    {
+        var phys = new Region(
+            PhysicalRow(region.Top), PhysicalRow(region.Bottom),
+            PhysicalCol(region.Left), PhysicalCol(region.Right));
+        return base.GetDataRegions(phys);
+    }
+
+    public new RegionRestoreData<T> Add(IRegion region, T data)
+    {
+        var phys = new Region(
+            PhysicalRow(region.Top), PhysicalRow(region.Bottom),
+            PhysicalCol(region.Left), PhysicalCol(region.Right));
+        return base.Add(phys, data);
+    }
+
+    public override RegionRestoreData<T> Set(int row, int col, T value)
+    {
+        if (RowInserted(row) || ColInserted(col))
+        {
+            var rr = new RegionRestoreData<T>();
+            return rr; // nothing to set in inserted space
+        }
+        return base.Set(PhysicalRow(row), PhysicalCol(col), value);
+    }
+
+    public new RegionRestoreData<T> InsertRowColAt(int index, int count, Axis axis)
+    {
+        if (axis == Axis.Row)
+            _rowOffsets.Insert(index, count);
+        else
+            _colOffsets.Insert(index, count);
+        return new RegionRestoreData<T>()
+        {
+            Shifts = [new(axis, index, count, null)]
+        };
+    }
+
+    public new RegionRestoreData<T> RemoveRowColAt(int index, int count, Axis axis)
+    {
+        if (axis == Axis.Row)
+            _rowOffsets.Remove(index, count);
+        else
+            _colOffsets.Remove(index, count);
+        return new RegionRestoreData<T>()
+        {
+            Shifts = [new(axis, index, -count, null)]
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add an `OffsetManager` helper that tracks cumulative index shifts
- introduce `OffsetRegionDataStore` that relies on offsets instead of shifting data

## Testing
- `dotnet test` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a6093bef88332a822d86f4df94f64